### PR TITLE
Adds support for .heic file type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "clsx": "^2.1.1",
         "eslint": "8.47.0",
         "eslint-config-next": "13.4.17",
+        "heic2any": "0.0.4",
         "jszip": "^3.10.1",
         "lucide-react": "^0.378.0",
         "next": "^14.2.3",
@@ -2197,6 +2198,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/heic2any": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/heic2any/-/heic2any-0.0.4.tgz",
+      "integrity": "sha512-3lLnZiDELfabVH87htnRolZ2iehX9zwpRyGNz22GKXIu0fznlblf0/ftppXKNqS26dqFSeqfIBhAmAj/uSp0cA==",
+      "license": "MIT"
     },
     "node_modules/ignore": {
       "version": "5.2.4",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "clsx": "^2.1.1",
     "eslint": "8.47.0",
     "eslint-config-next": "13.4.17",
+    "heic2any": "0.0.4",
     "jszip": "^3.10.1",
     "lucide-react": "^0.378.0",
     "next": "^14.2.3",

--- a/src/components/Dropzone/Dropzone.tsx
+++ b/src/components/Dropzone/Dropzone.tsx
@@ -179,18 +179,6 @@ const Dropzone = ({ className = '', onDrop, disabled = false, maxFiles, maxSize 
     return false;
   }
 
-  function getAcceptedFileTypes(accept: Record<string, Array<string>> | undefined): string | undefined {
-    if (!accept) return undefined;
-    
-    let acceptedMimeTypes = [] as string[];
-    Object.entries(accept).forEach(([mimeType, extensions]) => {
-      if (mimeType === 'image/heif') acceptedMimeTypes.push(...extensions); // The browser does not support the image/heif MIME type, so we need to add the extensions
-      else acceptedMimeTypes.push(mimeType);
-    });
-
-    return acceptedMimeTypes.join(', ');
-  }
-
   return (
     <>
       <div className={cn(dropzoneStyles, className)}>
@@ -222,7 +210,7 @@ const Dropzone = ({ className = '', onDrop, disabled = false, maxFiles, maxSize 
                 className="sr-only"
                 onChange={onFileInputChange}
                 type="file"
-                accept={getAcceptedFileTypes(accept)}
+                accept={accept ? Object.entries(accept).map(([key]) => key).join(', ') : undefined}
                 multiple
               />
             </div>

--- a/src/components/Dropzone/Dropzone.tsx
+++ b/src/components/Dropzone/Dropzone.tsx
@@ -179,6 +179,18 @@ const Dropzone = ({ className = '', onDrop, disabled = false, maxFiles, maxSize 
     return false;
   }
 
+  function getAcceptedFileTypes(accept: Record<string, Array<string>> | undefined): string | undefined {
+    if (!accept) return undefined;
+    
+    let acceptedMimeTypes = [] as string[];
+    Object.entries(accept).forEach(([mimeType, extensions]) => {
+      if (mimeType === 'image/heif') acceptedMimeTypes.push(...extensions); // The browser does not support the image/heif MIME type, so we need to add the extensions
+      else acceptedMimeTypes.push(mimeType);
+    });
+
+    return acceptedMimeTypes.join(', ');
+  }
+
   return (
     <>
       <div className={cn(dropzoneStyles, className)}>
@@ -210,7 +222,7 @@ const Dropzone = ({ className = '', onDrop, disabled = false, maxFiles, maxSize 
                 className="sr-only"
                 onChange={onFileInputChange}
                 type="file"
-                accept={accept ? Object.entries(accept).map(([key]) => key).join(', ') : undefined}
+                accept={getAcceptedFileTypes(accept)}
                 multiple
               />
             </div>

--- a/src/components/WidgetUpload/WidgetUpload.tsx
+++ b/src/components/WidgetUpload/WidgetUpload.tsx
@@ -344,6 +344,7 @@ const WidgetUpload = ({ className }: WidgetUploadProps) => {
             'image/webp': ['.webp'],
             'image/jxl': ['.jxl'],
             'image/heif': ['.heic', '.heif'],
+            'image/heic': ['.heic'],
           }}
           onDrop={(droppedFile) => {
             const dropDate = Date.now();

--- a/src/components/WidgetUpload/WidgetUpload.tsx
+++ b/src/components/WidgetUpload/WidgetUpload.tsx
@@ -343,6 +343,7 @@ const WidgetUpload = ({ className }: WidgetUploadProps) => {
             'image/png': ['.png'],
             'image/webp': ['.webp'],
             'image/jxl': ['.jxl'],
+            'image/heif': ['.heic'],
           }}
           onDrop={(droppedFile) => {
             const dropDate = Date.now();

--- a/src/components/WidgetUpload/WidgetUpload.tsx
+++ b/src/components/WidgetUpload/WidgetUpload.tsx
@@ -343,7 +343,7 @@ const WidgetUpload = ({ className }: WidgetUploadProps) => {
             'image/png': ['.png'],
             'image/webp': ['.webp'],
             'image/jxl': ['.jxl'],
-            'image/heif': ['.heic'],
+            'image/heif': ['.heic', '.heif'],
           }}
           onDrop={(droppedFile) => {
             const dropDate = Date.now();

--- a/src/lib/image.ts
+++ b/src/lib/image.ts
@@ -1,5 +1,3 @@
-import heic2any from "heic2any";
-
 /**
  * resizeImage
  */
@@ -37,7 +35,7 @@ interface ReadImageReturn {
   data: string | ArrayBuffer | null;
 }
 
-export function readImage(file: File|Blob): Promise<ReadImageReturn> {
+export function readImage(file: File): Promise<ReadImageReturn> {
   return new Promise(async (resolve, reject) => {
     const reader = new FileReader;
 
@@ -58,8 +56,9 @@ export function readImage(file: File|Blob): Promise<ReadImageReturn> {
       img.src = reader.result as string;
     };
 
-    if (file.type === 'image/heif') {
-      file = await heic2any({ blob: file, toType: 'image/jpeg' }) as Blob;
+    if (file.type === 'image/heif' && file.name.endsWith('.heic') && typeof window !== 'undefined') {
+      const heic2any = (await import('heic2any')).default;
+      file = await heic2any({ blob: file, toType: 'image/jpeg' }) as File;
     }
 
     reader.readAsDataURL(file);
@@ -77,7 +76,7 @@ const formatsMap: Record<string, string> = {
   jxl: 'JXL',
   png: 'PNG',
   webp: 'WebP',
-  heic: 'HEIC',
+  heif: 'HEIF',
 }
 
 export function getImageFormatFromType(type: string, formatted = false) {

--- a/src/lib/image.ts
+++ b/src/lib/image.ts
@@ -1,3 +1,5 @@
+import heic2any from "heic2any";
+
 /**
  * resizeImage
  */
@@ -35,8 +37,8 @@ interface ReadImageReturn {
   data: string | ArrayBuffer | null;
 }
 
-export function readImage(file: File): Promise<ReadImageReturn> {
-  return new Promise((resolve, reject) => {
+export function readImage(file: File|Blob): Promise<ReadImageReturn> {
+  return new Promise(async (resolve, reject) => {
     const reader = new FileReader;
 
     reader.onload = function() {
@@ -56,8 +58,12 @@ export function readImage(file: File): Promise<ReadImageReturn> {
       img.src = reader.result as string;
     };
 
+    if (file.type === 'image/heif') {
+      file = await heic2any({ blob: file, toType: 'image/jpeg' }) as Blob;
+    }
+
     reader.readAsDataURL(file);
-  })  
+  })
 }
 
 /**
@@ -71,6 +77,7 @@ const formatsMap: Record<string, string> = {
   jxl: 'JXL',
   png: 'PNG',
   webp: 'WebP',
+  heic: 'HEIC',
 }
 
 export function getImageFormatFromType(type: string, formatted = false) {

--- a/src/lib/image.ts
+++ b/src/lib/image.ts
@@ -56,7 +56,13 @@ export function readImage(file: File): Promise<ReadImageReturn> {
       img.src = reader.result as string;
     };
 
-    if (file.type === 'image/heif' && file.name.endsWith('.heic') && typeof window !== 'undefined') {
+    // HEIF/HEIC files aren't currently supported in most desktop browsers meaning 
+    // if we try to decode them, we'll get an error. This allows us to support these
+    // file types loading asynchronously a package that decode it for us into a jpg
+
+    const isHeif = file.type === 'image/heif' || file.type === 'image/heic';
+
+    if ( isHeif && typeof window !== 'undefined' ) {
       const heic2any = (await import('heic2any')).default;
       file = await heic2any({ blob: file, toType: 'image/jpeg' }) as File;
     }
@@ -77,6 +83,7 @@ const formatsMap: Record<string, string> = {
   png: 'PNG',
   webp: 'WebP',
   heif: 'HEIF',
+  heic: 'HEIC',
 }
 
 export function getImageFormatFromType(type: string, formatted = false) {

--- a/src/types/image.ts
+++ b/src/types/image.ts
@@ -12,6 +12,7 @@ export interface ImageUpload {
   optimized?: ImageDownload;
   avif?: ImageDownload;
   webp?: ImageDownload;
+  heic?: ImageDownload;
   jpeg?: ImageDownload;
   jxl?: ImageDownload;
   width?: number;


### PR DESCRIPTION
> This PR adds support for .heic image files used by iOS devices by adding the heic2any package. This package converts .heic files to a browser-compatible Blob format.
> 
> Browsers don't natively support .heic files, so this change ensures they can be properly displayed and handled on the web

Branched from https://github.com/cloudinary-community/imgto.xyz/pull/5

Includes additional fixes

Thanks @negativems