### PR TITLE
Fix: Fixed double file extension in zip

### DIFF
--- a/src/app/api/archive/route.ts
+++ b/src/app/api/archive/route.ts
@@ -14,7 +14,7 @@ export async function GET(request: Request) {
     const downloads = await Promise.all(urls?.map(async ({ url, name, format }: ArchiveDownload) => {
       return {
         data: await fetch(url).then(r => r.arrayBuffer()),
-        name: `${name}.${format}`
+        name: `${name.split('.')[0]}.${format}`
       }
     }));
 


### PR DESCRIPTION
Earlier, files inside the zip file (when we are downloading all) was being name with double extension (#9 )
Before:
<img width="340" alt="Screenshot 2024-09-12 at 1 11 15 AM" src="https://github.com/user-attachments/assets/7e7276f6-9916-453b-a334-cbc42833d005">

Now it is fixed

<img width="338" alt="Screenshot 2024-09-12 at 1 11 52 AM" src="https://github.com/user-attachments/assets/2ce6a4a6-fc3f-4f0a-9b07-560613a977b2">
